### PR TITLE
feat: 카카오 로그인 구현

### DIFF
--- a/src/main/java/com/pj2z/pj2zbe/auth/repository/UserRepository.java
+++ b/src/main/java/com/pj2z/pj2zbe/auth/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    Optional<User> findById(Long id);
 }

--- a/src/main/java/com/pj2z/pj2zbe/common/config/SecurityConfig.java
+++ b/src/main/java/com/pj2z/pj2zbe/common/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
                 .logout(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/signup", "/login").permitAll()
+                        .requestMatchers("/callback/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/pj2z/pj2zbe/oauthKakao/controller/KakaoLoginController.java
+++ b/src/main/java/com/pj2z/pj2zbe/oauthKakao/controller/KakaoLoginController.java
@@ -1,0 +1,24 @@
+package com.pj2z.pj2zbe.oauthKakao.controller;
+
+import com.pj2z.pj2zbe.auth.controller.dto.response.TokenResponse;
+import com.pj2z.pj2zbe.oauthKakao.service.KakaoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/callback")
+public class KakaoLoginController {
+
+    private final KakaoService kakaoService;
+
+    @GetMapping
+    public @ResponseBody TokenResponse kakaoLogin(@RequestParam("code") String code) {
+        String kakaoAccessToken = kakaoService.getAccessToken(code);
+        TokenResponse token = kakaoService.loginOrSignUp(kakaoAccessToken);
+        log.info("로그인 성공 !");
+        return token;
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/oauthKakao/controller/dto/KakaoTokenResDto.java
+++ b/src/main/java/com/pj2z/pj2zbe/oauthKakao/controller/dto/KakaoTokenResDto.java
@@ -1,0 +1,15 @@
+package com.pj2z.pj2zbe.oauthKakao.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoTokenResDto(
+        String tokenType,
+        String accessToken,
+        String idToken,
+        Integer expiresIn,
+        String refreshToken,
+        Integer refreshTokenExpiresIn,
+        String scope
+) {
+}

--- a/src/main/java/com/pj2z/pj2zbe/oauthKakao/controller/dto/KakaoUserInfo.java
+++ b/src/main/java/com/pj2z/pj2zbe/oauthKakao/controller/dto/KakaoUserInfo.java
@@ -1,0 +1,189 @@
+package com.pj2z.pj2zbe.oauthKakao.controller.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.HashMap;
+
+@Getter
+@NoArgsConstructor //역직렬화를 위한 기본 생성자
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfo {
+    //회원 번호
+    @JsonProperty("id")
+    public Long id;
+
+    //자동 연결 설정을 비활성화한 경우만 존재.
+    //true : 연결 상태, false : 연결 대기 상태
+    @JsonProperty("has_signed_up")
+    public Boolean hasSignedUp;
+
+    //서비스에 연결 완료된 시각. UTC
+    @JsonProperty("connected_at")
+    public Date connectedAt;
+
+    //카카오싱크 간편가입을 통해 로그인한 시각. UTC
+    @JsonProperty("synched_at")
+    public Date synchedAt;
+
+    //사용자 프로퍼티
+    @JsonProperty("properties")
+    public HashMap<String, String> properties;
+
+    //카카오 계정 정보
+    @JsonProperty("kakao_account")
+    public KakaoAccount kakaoAccount;
+
+    //uuid 등 추가 정보
+    @JsonProperty("for_partner")
+    public Partner partner;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAccount {
+
+        //프로필 정보 제공 동의 여부
+        @JsonProperty("profile_needs_agreement")
+        public Boolean isProfileAgree;
+
+        //닉네임 제공 동의 여부
+        @JsonProperty("profile_nickname_needs_agreement")
+        public Boolean isNickNameAgree;
+
+        //프로필 사진 제공 동의 여부
+        @JsonProperty("profile_image_needs_agreement")
+        public Boolean isProfileImageAgree;
+
+        //사용자 프로필 정보
+        @JsonProperty("profile")
+        public Profile profile;
+
+        //이름 제공 동의 여부
+        @JsonProperty("name_needs_agreement")
+        public Boolean isNameAgree;
+
+        //카카오계정 이름
+        @JsonProperty("name")
+        public String name;
+
+        //이메일 제공 동의 여부
+        @JsonProperty("email_needs_agreement")
+        public Boolean isEmailAgree;
+
+        //이메일이 유효 여부
+        // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
+        @JsonProperty("is_email_valid")
+        public Boolean isEmailValid;
+
+        //이메일이 인증 여부
+        //true : 인증된 이메일, false : 인증되지 않은 이메일
+        @JsonProperty("is_email_verified")
+        public Boolean isEmailVerified;
+
+        //카카오계정 대표 이메일
+        @JsonProperty("email")
+        public String email;
+
+        //연령대 제공 동의 여부
+        @JsonProperty("age_range_needs_agreement")
+        public Boolean isAgeAgree;
+
+        //연령대
+        //참고 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+        @JsonProperty("age_range")
+        public String ageRange;
+
+        //출생 연도 제공 동의 여부
+        @JsonProperty("birthyear_needs_agreement")
+        public Boolean isBirthYearAgree;
+
+        //출생 연도 (YYYY 형식)
+        @JsonProperty("birthyear")
+        public String birthYear;
+
+        //생일 제공 동의 여부
+        @JsonProperty("birthday_needs_agreement")
+        public Boolean isBirthDayAgree;
+
+        //생일 (MMDD 형식)
+        @JsonProperty("birthday")
+        public String birthDay;
+
+        //생일 타입
+        // SOLAR(양력) 혹은 LUNAR(음력)
+        @JsonProperty("birthday_type")
+        public String birthDayType;
+
+        //성별 제공 동의 여부
+        @JsonProperty("gender_needs_agreement")
+        public Boolean isGenderAgree;
+
+        //성별
+        @JsonProperty("gender")
+        public String gender;
+
+        //전화번호 제공 동의 여부
+        @JsonProperty("phone_number_needs_agreement")
+        public Boolean isPhoneNumberAgree;
+
+        //전화번호
+        //국내 번호인 경우 +82 00-0000-0000 형식
+        @JsonProperty("phone_number")
+        public String phoneNumber;
+
+        //CI 동의 여부
+        @JsonProperty("ci_needs_agreement")
+        public Boolean isCIAgree;
+
+        //CI, 연계 정보
+        @JsonProperty("ci")
+        public String ci;
+
+        //CI 발급 시각, UTC
+        @JsonProperty("ci_authenticated_at")
+        public Date ciCreatedAt;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public class Profile {
+
+            //닉네임
+            @JsonProperty("nickname")
+            public String nickName;
+
+            //프로필 미리보기 이미지 URL
+            @JsonProperty("thumbnail_image_url")
+            public String thumbnailImageUrl;
+
+            //프로필 사진 URL
+            @JsonProperty("profile_image_url")
+            public String profileImageUrl;
+
+            //프로필 사진 URL 기본 프로필인지 여부
+            //true : 기본 프로필, false : 사용자 등록
+            @JsonProperty("is_default_image")
+            public String isDefaultImage;
+
+            //닉네임이 기본 닉네임인지 여부
+            //true : 기본 닉네임, false : 사용자 등록
+            @JsonProperty("is_default_nickname")
+            public Boolean isDefaultNickName;
+
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class Partner {
+        //고유 ID
+        @JsonProperty("uuid")
+        public String uuid;
+    }
+
+}

--- a/src/main/java/com/pj2z/pj2zbe/oauthKakao/controller/dto/KakaoUserInfo.java
+++ b/src/main/java/com/pj2z/pj2zbe/oauthKakao/controller/dto/KakaoUserInfo.java
@@ -44,7 +44,7 @@ public class KakaoUserInfo {
     @Getter
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class KakaoAccount {
+    public static class KakaoAccount {
 
         //프로필 정보 제공 동의 여부
         @JsonProperty("profile_needs_agreement")
@@ -150,7 +150,7 @@ public class KakaoUserInfo {
         @Getter
         @NoArgsConstructor
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public class Profile {
+        public static class Profile {
 
             //닉네임
             @JsonProperty("nickname")
@@ -180,7 +180,7 @@ public class KakaoUserInfo {
     @Getter
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class Partner {
+    public static class Partner {
         //고유 ID
         @JsonProperty("uuid")
         public String uuid;

--- a/src/main/java/com/pj2z/pj2zbe/oauthKakao/service/KakaoService.java
+++ b/src/main/java/com/pj2z/pj2zbe/oauthKakao/service/KakaoService.java
@@ -1,0 +1,83 @@
+package com.pj2z.pj2zbe.oauthKakao.service;
+
+import com.pj2z.pj2zbe.auth.controller.dto.response.TokenResponse;
+import com.pj2z.pj2zbe.auth.entity.Role;
+import com.pj2z.pj2zbe.auth.entity.User;
+import com.pj2z.pj2zbe.auth.repository.UserRepository;
+import com.pj2z.pj2zbe.common.jwt.JwtUtil;
+import com.pj2z.pj2zbe.oauthKakao.controller.dto.KakaoTokenResDto;
+import com.pj2z.pj2zbe.oauthKakao.controller.dto.KakaoUserInfo;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoService {
+
+    @Value("${kakao.client_id}")
+    private String clientId;
+
+    private final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com"; // 액세스 토큰을 발급받기 위한 서버
+    private final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com"; // 사용자 정보를 받아오기 위한 서버
+
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    public String getAccessToken(String code) {
+
+        KakaoTokenResDto kakaoTokenResDto = WebClient.create(KAUTH_TOKEN_URL_HOST).post()// 카카오 인증 서버로 post 요청 준비
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientId)
+                        .queryParam("code", code)
+                        .build(true))
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve() // 요청을 보내고 응답 받기
+                .bodyToMono(KakaoTokenResDto.class) // 카카오 서버로부터 받아온 응답 본문을 dto로 변환
+                .block(); // 비동기 방식으로 처리된 결과를 동기적으로 받을 수 있게
+
+        return kakaoTokenResDto.accessToken();
+    }
+
+    public KakaoUserInfo getUserInfo(String accessToken) {
+
+        KakaoUserInfo userInfo = WebClient.create(KAUTH_USER_URL_HOST)
+                .get()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .path("/v2/user/me")
+                        .build(true))
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())
+                .retrieve()
+                .bodyToMono(KakaoUserInfo.class)
+                .block();
+
+        return userInfo;
+    }
+
+    @Transactional
+    public TokenResponse loginOrSignUp(String kakaoAccessToken) {
+        KakaoUserInfo userInfo = getUserInfo(kakaoAccessToken);
+        Long id = userInfo.getId();
+
+        User user = userRepository.findById(id).orElseGet(() ->
+                userRepository.save(User.builder()
+                        .email(userInfo.getKakaoAccount().getEmail())
+                        .role(Role.ROLE_USER)
+                        .build())
+
+        );
+
+        return jwtUtil.generateTokens(user.getId());
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/oauthKakao/service/KakaoService.java
+++ b/src/main/java/com/pj2z/pj2zbe/oauthKakao/service/KakaoService.java
@@ -24,8 +24,8 @@ public class KakaoService {
     @Value("${kakao.client_id}")
     private String clientId;
 
-    private final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com"; // 액세스 토큰을 발급받기 위한 서버
-    private final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com"; // 사용자 정보를 받아오기 위한 서버
+    private static final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com"; // 액세스 토큰을 발급받기 위한 서버
+    private static final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com"; // 사용자 정보를 받아오기 위한 서버
 
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
@@ -50,7 +50,7 @@ public class KakaoService {
 
     public KakaoUserInfo getUserInfo(String accessToken) {
 
-        KakaoUserInfo userInfo = WebClient.create(KAUTH_USER_URL_HOST)
+        return WebClient.create(KAUTH_USER_URL_HOST)
                 .get()
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
@@ -61,8 +61,6 @@ public class KakaoService {
                 .retrieve()
                 .bodyToMono(KakaoUserInfo.class)
                 .block();
-
-        return userInfo;
     }
 
     @Transactional


### PR DESCRIPTION
## 🔎 작업 내용
- 카카오 인증 서버로 post요청으로 access token 받아오는 로직
- 위의 access token으로 사용자 정보를 받아와서 회원가입 또는 로그인하는 로직
    - access token, refresh token 모두 발급

## ➕ 이슈 링크
- #8 

## 🧑‍💻 예정 작업

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?