### PR TITLE
refactor: 기존 gpt 활용한 선택 로직 리팩토링

### DIFF
--- a/src/main/java/com/pj2z/pj2zbe/common/config/OpenAIConfig.java
+++ b/src/main/java/com/pj2z/pj2zbe/common/config/OpenAIConfig.java
@@ -1,4 +1,4 @@
-package com.pj2z.pj2zbe.recommend.config;
+package com.pj2z.pj2zbe.common.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/pj2z/pj2zbe/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pj2z/pj2zbe/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.pj2z.pj2zbe.common.exception;
 
+import com.pj2z.pj2zbe.mbti.exception.MbtiNotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +18,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             UserNotFoundException.class,
             TestNotFoundException.class,
-            GoalNotFoundException.class
+            GoalNotFoundException.class,
+            MbtiNotFoundException.class
     })
     public ResponseEntity<Map<String, Object>> handleNotFound(RuntimeException e) {
         log.error(e.getMessage());

--- a/src/main/java/com/pj2z/pj2zbe/mbti/entity/Mbti.java
+++ b/src/main/java/com/pj2z/pj2zbe/mbti/entity/Mbti.java
@@ -1,10 +1,9 @@
 package com.pj2z.pj2zbe.mbti.entity;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.pj2z.pj2zbe.user.entity.User;
 import com.pj2z.pj2zbe.common.entity.BaseTimeEntity;
 import com.pj2z.pj2zbe.mbti.core.MbtiPairSum;
 import com.pj2z.pj2zbe.mbti.entity.enums.MbtiType;
+import com.pj2z.pj2zbe.user.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -12,10 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -37,6 +32,7 @@ public class Mbti extends BaseTimeEntity {
     @Column(nullable = false, name = "mbti_type")
     @Enumerated(EnumType.STRING)
     private MbtiType mbtiType;
+
     @Max(100) @Min(0)
     @Column(nullable = false, name = "e_percent")
     private Long ePercent;
@@ -51,15 +47,12 @@ public class Mbti extends BaseTimeEntity {
     @Column(nullable = false, name = "s_percent")
     private Long sPercent;
 
-
     @Max(100) @Min(0)
     @Column(nullable = false, name = "t_percent")
     private Long tPercent;
-
     @Max(100) @Min(0)
     @Column(nullable = false, name = "f_percent")
     private Long fPercent;
-
 
     @Max(100) @Min(0)
     @Column(nullable = false, name = "p_percent")
@@ -67,19 +60,4 @@ public class Mbti extends BaseTimeEntity {
     @Max(100) @Min(0)
     @Column(nullable = false, name = "j_percent")
     private Long jPercent;
-
-
-    @CreatedDate
-    @Column(updatable = false)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
-    @Temporal(TemporalType.TIMESTAMP)
-    private LocalDateTime modifiedAt;
-
 }
-

--- a/src/main/java/com/pj2z/pj2zbe/mbti/exception/MbtiNotFoundException.java
+++ b/src/main/java/com/pj2z/pj2zbe/mbti/exception/MbtiNotFoundException.java
@@ -1,0 +1,7 @@
+package com.pj2z.pj2zbe.mbti.exception;
+
+public class MbtiNotFoundException extends RuntimeException {
+    public MbtiNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/mbti/repository/MbtiRepository.java
+++ b/src/main/java/com/pj2z/pj2zbe/mbti/repository/MbtiRepository.java
@@ -1,8 +1,7 @@
 package com.pj2z.pj2zbe.mbti.repository;
 
-import com.pj2z.pj2zbe.user.entity.User;
 import com.pj2z.pj2zbe.mbti.entity.Mbti;
-import com.pj2z.pj2zbe.user.entity.UserEntity;
+import com.pj2z.pj2zbe.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,9 +9,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MbtiRepository  extends JpaRepository<Mbti, Long> {
-       Page<Mbti> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
-
-
+    Page<Mbti> findByUserOrderByCreatedAtDesc(User user, Pageable pageable);
     Optional<Mbti> findTopByUserOrderByCreatedAtDesc(User user);
-
 }

--- a/src/main/java/com/pj2z/pj2zbe/recommend/dto/request/RecommendRequest.java
+++ b/src/main/java/com/pj2z/pj2zbe/recommend/dto/request/RecommendRequest.java
@@ -1,10 +1,12 @@
 package com.pj2z.pj2zbe.recommend.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public record RecommendRequest(
+        @NotNull
         Long userId,
         String setting,
         @NotBlank

--- a/src/main/java/com/pj2z/pj2zbe/recommend/service/RecommendService.java
+++ b/src/main/java/com/pj2z/pj2zbe/recommend/service/RecommendService.java
@@ -100,7 +100,7 @@ public class RecommendService {
         values.put("ppercent", String.valueOf(mbti.getPPercent()));
 
         for (Map.Entry<String, String> entry : values.entrySet()) {
-            promptTemplate = promptTemplate.replace("{{" + entry.getKey() + "}}", entry.getValue());
+            promptTemplate = promptTemplate.replace("{{ " + entry.getKey() + " }}", entry.getValue());
         }
         return promptTemplate;
     }

--- a/src/main/java/com/pj2z/pj2zbe/recommend/service/RecommendService.java
+++ b/src/main/java/com/pj2z/pj2zbe/recommend/service/RecommendService.java
@@ -23,7 +23,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.List;
 
 @Slf4j
-
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -50,7 +49,7 @@ public class RecommendService {
         Mbti mbti = mbtiRepository.findTopByUserOrderByCreatedAtDesc(user)
                 .orElseThrow(() -> new RuntimeException("mbti not found"));
 
-        List<String> goalNames = fetchUserGoals(user, request.userId());
+        List<String> goalNames = fetchUserGoals(user.getUserGoalYN(), request.userId());
 
         String prompt = createPrompt(request, mbti, goalNames);
         ChatGPTResponse gptResponse = sendRequestToGPT(prompt);
@@ -58,8 +57,8 @@ public class RecommendService {
         return formatGPTResponse(gptResponse);
     }
 
-    private List<String> fetchUserGoals(User user, Long userId) {
-        if (user.getUserGoalYN() == UserGoalYN.N) {
+    private List<String> fetchUserGoals(UserGoalYN goalChoice, Long userId) {
+        if (goalChoice == UserGoalYN.N) {
             return null;
         }
         return userGoalRepository.findAllByUserId(userId)


### PR DESCRIPTION
## 🔎 작업 내용
- 기존의 String.format()이 아닌 key-value 매핑 방식으로 변경
    - 이렇게 수정 시에 순서와 무관하게 치환이 가능하기 때문에 유지보수성이 올라감.
    - 가독성 향상

## ➕ 이슈 링크
- #13 

## 📸 스크린샷(선택)
<img width="652" alt="image" src="https://github.com/user-attachments/assets/420b6033-2246-42d7-830f-649bea32006a" />

## 🧑‍💻 예정 작업
- #14 
## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?