### PR TITLE
feat: 투표 참여 API 구현

### DIFF
--- a/src/main/java/com/pj2z/pj2zbe/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pj2z/pj2zbe/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.pj2z.pj2zbe.common.exception;
 
 import com.pj2z.pj2zbe.community.exception.VoteDeadlineException;
+import com.pj2z.pj2zbe.community.exception.VoteNotFoundException;
 import com.pj2z.pj2zbe.mbti.exception.MbtiNotFoundException;
 import com.pj2z.pj2zbe.recommend.exception.NoTicketsException;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +31,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({
             NoTicketsException.class,
-            VoteDeadlineException.class
+            VoteDeadlineException.class,
+            VoteNotFoundException.class
     })
     public ResponseEntity<Map<String, Object>> handleBadRequest(RuntimeException e) {
         log.error(e.getMessage());
@@ -58,4 +60,3 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errorResponse, status);
     }
 }
-

--- a/src/main/java/com/pj2z/pj2zbe/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pj2z/pj2zbe/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.pj2z.pj2zbe.common.exception;
 
 import com.pj2z.pj2zbe.community.exception.VoteDeadlineException;
-import com.pj2z.pj2zbe.community.exception.VoteNotFoundException;
+import com.pj2z.pj2zbe.community.exception.AlreadyVotedException;
 import com.pj2z.pj2zbe.mbti.exception.MbtiNotFoundException;
 import com.pj2z.pj2zbe.recommend.exception.NoTicketsException;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({
             NoTicketsException.class,
             VoteDeadlineException.class,
-            VoteNotFoundException.class
+            AlreadyVotedException.class
     })
     public ResponseEntity<Map<String, Object>> handleBadRequest(RuntimeException e) {
         log.error(e.getMessage());

--- a/src/main/java/com/pj2z/pj2zbe/community/controller/VoteController.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/controller/VoteController.java
@@ -1,0 +1,28 @@
+package com.pj2z.pj2zbe.community.controller;
+
+import com.pj2z.pj2zbe.common.custom.UserCheck;
+import com.pj2z.pj2zbe.community.dto.VoteRequest;
+import com.pj2z.pj2zbe.community.dto.VoteResponse;
+import com.pj2z.pj2zbe.community.service.VoteService;
+import com.pj2z.pj2zbe.user.entity.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts/vote")
+public class VoteController {
+
+    private final VoteService voteService;
+
+    @PutMapping("/{voteId}")
+    public ResponseEntity<VoteResponse> updateVote(@UserCheck User user,
+                                                   @PathVariable Long voteId,
+                                                   @RequestBody @Valid VoteRequest voteRequest) {
+        VoteResponse response = voteService.updateVoteCount(user, voteId, voteRequest);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/dto/PostCreateResponse.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/dto/PostCreateResponse.java
@@ -1,6 +1,7 @@
 package com.pj2z.pj2zbe.community.dto;
 
 public record PostCreateResponse(
-        Long postId
+        Long postId,
+        Long voteId
 ) {
 }

--- a/src/main/java/com/pj2z/pj2zbe/community/dto/VoteRequest.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/dto/VoteRequest.java
@@ -1,0 +1,8 @@
+package com.pj2z.pj2zbe.community.dto;
+
+import com.pj2z.pj2zbe.community.entity.VoteType;
+
+public record VoteRequest(
+        VoteType voteType
+) {
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/dto/VoteResponse.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/dto/VoteResponse.java
@@ -1,0 +1,11 @@
+package com.pj2z.pj2zbe.community.dto;
+
+public record VoteResponse(
+        Long voteId,
+        Integer voteACount,
+        Integer voteBCount,
+        Double totalVoteCount,
+        Double voteAPercentage,
+        Double voteBPercentage
+) {
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/entity/Vote.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/entity/Vote.java
@@ -35,4 +35,12 @@ public class Vote extends BaseTimeEntity {
         this.voteB = voteB;
         this.voteDeadline = voteDeadline!= null ? voteDeadline : LocalDateTime.now().plusDays(7);
     }
+
+    public void updateAVoteCount(){
+        voteACount++;
+    }
+
+    public void updateBVoteCount(){
+        voteBCount++;
+    }
 }

--- a/src/main/java/com/pj2z/pj2zbe/community/entity/VoteRecord.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/entity/VoteRecord.java
@@ -1,0 +1,32 @@
+package com.pj2z.pj2zbe.community.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class VoteRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long voteId;
+    private Long postId;
+
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private VoteType voteType;    // A or B ...
+
+    @Builder
+    public VoteRecord(Long voteId, Long postId, Long userId, VoteType voteType) {
+        this.voteId = voteId;
+        this.postId = postId;
+        this.userId = userId;
+        this.voteType = voteType;
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/entity/VoteType.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/entity/VoteType.java
@@ -1,0 +1,6 @@
+package com.pj2z.pj2zbe.community.entity;
+
+public enum VoteType {
+    A,
+    B
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/exception/AlreadyVotedException.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/exception/AlreadyVotedException.java
@@ -1,0 +1,7 @@
+package com.pj2z.pj2zbe.community.exception;
+
+public class AlreadyVotedException extends RuntimeException {
+    public AlreadyVotedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/exception/VoteNotFoundException.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/exception/VoteNotFoundException.java
@@ -1,7 +1,0 @@
-package com.pj2z.pj2zbe.community.exception;
-
-public class VoteNotFoundException extends RuntimeException {
-    public VoteNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/pj2z/pj2zbe/community/exception/VoteNotFoundException.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/exception/VoteNotFoundException.java
@@ -1,0 +1,7 @@
+package com.pj2z.pj2zbe.community.exception;
+
+public class VoteNotFoundException extends RuntimeException {
+    public VoteNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/exception/VoteTypeException.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/exception/VoteTypeException.java
@@ -1,0 +1,7 @@
+package com.pj2z.pj2zbe.community.exception;
+
+public class VoteTypeException extends RuntimeException {
+    public VoteTypeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/repository/VoteRecordRepository.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/repository/VoteRecordRepository.java
@@ -1,0 +1,8 @@
+package com.pj2z.pj2zbe.community.repository;
+
+import com.pj2z.pj2zbe.community.entity.VoteRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VoteRecordRepository  extends JpaRepository<VoteRecord, Long> {
+    boolean existsByVoteIdAndUserId(Long voteId, Long userId);
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/service/PostService.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/service/PostService.java
@@ -35,7 +35,7 @@ public class PostService {
                 request.voteForm().voteDeadline());
         voteRepository.save(vote);
 
-        return new PostCreateResponse(post.getId());
+        return new PostCreateResponse(post.getId(), vote.getId());
     }
 
     private void validateVoteDeadline(LocalDateTime voteDeadline) {

--- a/src/main/java/com/pj2z/pj2zbe/community/service/VoteService.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/service/VoteService.java
@@ -5,7 +5,7 @@ import com.pj2z.pj2zbe.community.dto.VoteResponse;
 import com.pj2z.pj2zbe.community.entity.Vote;
 import com.pj2z.pj2zbe.community.entity.VoteRecord;
 import com.pj2z.pj2zbe.community.entity.VoteType;
-import com.pj2z.pj2zbe.community.exception.VoteNotFoundException;
+import com.pj2z.pj2zbe.community.exception.AlreadyVotedException;
 import com.pj2z.pj2zbe.community.exception.VoteTypeException;
 import com.pj2z.pj2zbe.community.repository.VoteRecordRepository;
 import com.pj2z.pj2zbe.community.repository.VoteRepository;
@@ -43,13 +43,13 @@ public class VoteService {
 
     private void checkVoteRecordExists(Long userId, Long voteId) {
         if (voteRecordRepository.existsByVoteIdAndUserId(voteId, userId)) {
-            throw new VoteNotFoundException("이미 투표한 사용자입니다.");
+            throw new AlreadyVotedException("이미 투표한 사용자입니다.");
         }
     }
 
     private Vote addVoteAndReturn(Long voteId, VoteRequest voteRequest) {
         Vote vote = voteRepository.findById(voteId)
-                .orElseThrow(() -> new VoteNotFoundException("해당 투표가 존재하지 않습니다."));
+                .orElseThrow(() -> new AlreadyVotedException("해당 투표가 존재하지 않습니다."));
 
         switch (voteRequest.voteType()) {
             case A -> vote.updateAVoteCount();

--- a/src/main/java/com/pj2z/pj2zbe/community/service/VoteService.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/service/VoteService.java
@@ -1,0 +1,71 @@
+package com.pj2z.pj2zbe.community.service;
+
+import com.pj2z.pj2zbe.community.dto.VoteRequest;
+import com.pj2z.pj2zbe.community.dto.VoteResponse;
+import com.pj2z.pj2zbe.community.entity.Vote;
+import com.pj2z.pj2zbe.community.entity.VoteRecord;
+import com.pj2z.pj2zbe.community.entity.VoteType;
+import com.pj2z.pj2zbe.community.exception.VoteNotFoundException;
+import com.pj2z.pj2zbe.community.exception.VoteTypeException;
+import com.pj2z.pj2zbe.community.repository.VoteRecordRepository;
+import com.pj2z.pj2zbe.community.repository.VoteRepository;
+import com.pj2z.pj2zbe.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VoteService {
+
+    private final VoteRepository voteRepository;
+    private final VoteRecordRepository voteRecordRepository;
+
+    @Transactional
+    public VoteResponse updateVoteCount(User user, Long voteId, VoteRequest voteRequest) {
+        checkVoteRecordExists(user.getId(), voteId);
+
+        Vote vote = addVoteAndReturn(voteId, voteRequest);
+        voteRepository.save(vote);
+
+        createVoteRecord(user, vote, voteRequest.voteType());
+
+        double totalVoteCount = vote.getVoteACount() + vote.getVoteBCount();
+        return new VoteResponse(
+                voteId,
+                vote.getVoteACount(),
+                vote.getVoteBCount(),
+                totalVoteCount,
+                vote.getVoteACount() / totalVoteCount * 100,
+                vote.getVoteBCount() / totalVoteCount * 100
+        );
+    }
+
+    private void checkVoteRecordExists(Long userId, Long voteId) {
+        if (voteRecordRepository.existsByVoteIdAndUserId(voteId, userId)) {
+            throw new VoteNotFoundException("이미 투표한 사용자입니다.");
+        }
+    }
+
+    private Vote addVoteAndReturn(Long voteId, VoteRequest voteRequest) {
+        Vote vote = voteRepository.findById(voteId)
+                .orElseThrow(() -> new VoteNotFoundException("해당 투표가 존재하지 않습니다."));
+
+        switch (voteRequest.voteType()) {
+            case A -> vote.updateAVoteCount();
+            case B -> vote.updateBVoteCount();
+            default -> throw new VoteTypeException("올바르지 않은 투표 타입입니다: " + voteRequest.voteType());
+        }
+        return vote;
+    }
+
+    private void createVoteRecord(User user, Vote vote, VoteType voteType) {
+        VoteRecord voteRecord = VoteRecord.builder()
+                .voteId(vote.getId())
+                .postId(vote.getPostId())
+                .userId(user.getId())
+                .voteType(voteType)
+                .build();
+        voteRecordRepository.save(voteRecord);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 투표 참여 API 
    - a나 b 투표 시 해당 count 증가
    - vote record에 user 정보와 함께 저장(재투표 불가)
- 기타 작업(이전 이슈 변경사항): post 생성 API의 response: vote 고유 id 추가
## ➕ 이슈 링크
- #34 

## 📸 스크린샷(선택)

### - 투표 시 
<img width="870" alt="image" src="https://github.com/user-attachments/assets/9cc1383c-9fd0-43e8-adbb-7e2b25271ada" />

### - 이미 투표한 경우(예외처리)
<img width="540" alt="image" src="https://github.com/user-attachments/assets/04630675-1987-43fc-a403-e646e3a7696c" />

## 🧑‍💻 예정 작업
- #35 

## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?