### PR TITLE
feat: 투표 현황 조회 API 구현

### DIFF
--- a/src/main/java/com/pj2z/pj2zbe/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pj2z/pj2zbe/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.pj2z.pj2zbe.common.exception;
 
 import com.pj2z.pj2zbe.community.exception.VoteDeadlineException;
 import com.pj2z.pj2zbe.community.exception.AlreadyVotedException;
+import com.pj2z.pj2zbe.community.exception.VoteNotFoundException;
 import com.pj2z.pj2zbe.mbti.exception.MbtiNotFoundException;
 import com.pj2z.pj2zbe.recommend.exception.NoTicketsException;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +23,8 @@ public class GlobalExceptionHandler {
             UserNotFoundException.class,
             TestNotFoundException.class,
             GoalNotFoundException.class,
-            MbtiNotFoundException.class
+            MbtiNotFoundException.class,
+            VoteNotFoundException.class
     })
     public ResponseEntity<Map<String, Object>> handleNotFound(RuntimeException e) {
         log.error(e.getMessage());

--- a/src/main/java/com/pj2z/pj2zbe/community/controller/VoteController.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/controller/VoteController.java
@@ -25,4 +25,10 @@ public class VoteController {
         VoteResponse response = voteService.updateVoteCount(user, voteId, voteRequest);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
+
+    @GetMapping("/{voteId}")
+    public ResponseEntity<VoteResponse> retrieveVote(@PathVariable Long voteId) {
+        VoteResponse response = voteService.retrieve(voteId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
 }

--- a/src/main/java/com/pj2z/pj2zbe/community/dto/VoteResponse.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/dto/VoteResponse.java
@@ -1,11 +1,34 @@
 package com.pj2z.pj2zbe.community.dto;
 
+import com.pj2z.pj2zbe.community.entity.Vote;
+
 public record VoteResponse(
         Long voteId,
+        String voteA,
+        String voteB,
         Integer voteACount,
         Integer voteBCount,
         Double totalVoteCount,
         Double voteAPercentage,
         Double voteBPercentage
 ) {
+    public static VoteResponse from(Vote vote) {
+        Integer voteACount = vote.getVoteACount();
+        Integer voteBCount = vote.getVoteBCount();
+        double totalVoteCount = voteACount + voteBCount;
+
+        double voteAPercentage = totalVoteCount > 0 ? (voteACount / totalVoteCount) * 100 : 0;
+        double voteBPercentage = totalVoteCount > 0 ? (voteBCount / totalVoteCount) * 100 : 0;
+
+        return new VoteResponse(
+                vote.getId(),
+                vote.getVoteA(),
+                vote.getVoteB(),
+                voteACount,
+                voteBCount,
+                totalVoteCount,
+                voteAPercentage,
+                voteBPercentage
+        );
+    }
 }

--- a/src/main/java/com/pj2z/pj2zbe/community/exception/VoteNotFoundException.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/exception/VoteNotFoundException.java
@@ -1,0 +1,7 @@
+package com.pj2z.pj2zbe.community.exception;
+
+public class VoteNotFoundException extends RuntimeException {
+    public VoteNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/pj2z/pj2zbe/community/service/PostService.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/service/PostService.java
@@ -8,9 +8,9 @@ import com.pj2z.pj2zbe.community.exception.VoteDeadlineException;
 import com.pj2z.pj2zbe.community.repository.PostRepository;
 import com.pj2z.pj2zbe.community.repository.VoteRepository;
 import com.pj2z.pj2zbe.user.entity.User;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/pj2z/pj2zbe/community/service/VoteService.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/service/VoteService.java
@@ -34,6 +34,14 @@ public class VoteService {
         return VoteResponse.from(vote);
     }
 
+    @Transactional(readOnly = true)
+    public VoteResponse retrieve(Long voteId) {
+        Vote vote = voteRepository.findById(voteId)
+                .orElseThrow(()-> new VoteNotFoundException("해당 투표가 존재하지 않습니다."));
+
+        return VoteResponse.from(vote);
+    }
+
     private void checkVoteRecordExists(Long userId, Long voteId) {
         if (voteRecordRepository.existsByVoteIdAndUserId(voteId, userId)) {
             throw new AlreadyVotedException("이미 투표한 사용자입니다.");

--- a/src/main/java/com/pj2z/pj2zbe/community/service/VoteService.java
+++ b/src/main/java/com/pj2z/pj2zbe/community/service/VoteService.java
@@ -6,13 +6,14 @@ import com.pj2z.pj2zbe.community.entity.Vote;
 import com.pj2z.pj2zbe.community.entity.VoteRecord;
 import com.pj2z.pj2zbe.community.entity.VoteType;
 import com.pj2z.pj2zbe.community.exception.AlreadyVotedException;
+import com.pj2z.pj2zbe.community.exception.VoteNotFoundException;
 import com.pj2z.pj2zbe.community.exception.VoteTypeException;
 import com.pj2z.pj2zbe.community.repository.VoteRecordRepository;
 import com.pj2z.pj2zbe.community.repository.VoteRepository;
 import com.pj2z.pj2zbe.user.entity.User;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,15 +31,7 @@ public class VoteService {
 
         createVoteRecord(user, vote, voteRequest.voteType());
 
-        double totalVoteCount = vote.getVoteACount() + vote.getVoteBCount();
-        return new VoteResponse(
-                voteId,
-                vote.getVoteACount(),
-                vote.getVoteBCount(),
-                totalVoteCount,
-                vote.getVoteACount() / totalVoteCount * 100,
-                vote.getVoteBCount() / totalVoteCount * 100
-        );
+        return VoteResponse.from(vote);
     }
 
     private void checkVoteRecordExists(Long userId, Long voteId) {


### PR DESCRIPTION
## 🔎 작업 내용
- 투표 현황 조회 API
    - 투표 마감 후, 투표 참여는 막히지만 기존 결과는 유지됨.
- 기타 작업(이전 이슈 변경사항): 투표할 때, 투표 조회할 때 사용되는 VoteResponse(DTO)에 `from` 메서드를 통해 응답 형식에 맞게 변환

## ➕ 이슈 링크
- #35 

## 📸 스크린샷(선택)

## 🧑‍💻 예정 작업
- #36 
## 📝 체크리스트
- [x] 브랜치 이름은 `feature/개발내용` 형식으로 작성했는가?
- [x] 커밋 메시지는 `feat: 커밋 내용` 형식으로 작성했는가?
- [x] 작업 전 Issue를 작성했는가?
- [x] 불필요한 주석과 공백은 제거했는가?
- [ ] 코드 리뷰어의 피드백을 반영했는가?
- [x] 테스트를 진행했는가?
- [ ] 테스트 코드를 작성했는가?